### PR TITLE
[HOME+SEARCH] 임시 데이터 삭제 후 백엔드 연동

### DIFF
--- a/app/src/main/java/com/example/qp/DetailedActivity.kt
+++ b/app/src/main/java/com/example/qp/DetailedActivity.kt
@@ -56,9 +56,7 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
 
         //검색으로 화면전환
         binding.detailedSearchBt.setOnClickListener {
-            val qDatas = intent.getSerializableExtra("qDatas") as ArrayList<QuestionInfo>
             val intent = Intent(this@DetailedActivity, SearchActivity::class.java)
-            intent.putExtra("qDatas", qDatas)
             startActivity(intent)
         }
 

--- a/app/src/main/java/com/example/qp/DetailedActivity.kt
+++ b/app/src/main/java/com/example/qp/DetailedActivity.kt
@@ -122,7 +122,7 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
     private fun initView(){
         binding.detailedQuestionTitleTv.text = questionInfo.title
         binding.detailedQuestionContentTv.text = questionInfo.content
-        binding.detailedQuestionTimeTv.text = questionInfo.createAt.toString()
+        binding.detailedQuestionTimeTv.text = questionInfo.createdAt.toString()
 
         val tagListSize = questionInfo.hashtags?.size
         when(tagListSize){

--- a/app/src/main/java/com/example/qp/MainActivity.kt
+++ b/app/src/main/java/com/example/qp/MainActivity.kt
@@ -42,7 +42,19 @@ class MainActivity : AppCompatActivity() {
         val questionRVAdapter = QuestionRVAdapter(qDatas)
         binding.mainQuestionRv.adapter = questionRVAdapter
         binding.mainQuestionRv.layoutManager = GridLayoutManager(applicationContext, 2)
-        
+
+        //특정 질문 클릭 시 질문상세화면으로 전환
+        questionRVAdapter.setMyItemClickListner(object : QuestionRVAdapter.MyItemClickListner{
+            override fun onItemClick(questionInfo: QuestionInfo) {
+                val intent = Intent(this@MainActivity, DetailedActivity::class.java)
+                val gson = Gson()
+                val qJson = gson.toJson(questionInfo)
+                intent.putExtra("question", qJson)
+                intent.putExtra("qDatas", qDatas)
+                startActivity(intent)
+            }
+        })
+
         // 키 해시 확인용
         val keyHash = Utility.getKeyHash(this)
         Log.d("Hash", keyHash)
@@ -77,39 +89,6 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
-
-//        getQuestions()
-//        qDatas.apply {
-//            add(Question("2023.11.16","질문 제목1","질문내용1","#태그1","#태그2","#태그3"))
-//            add(Question("2023.12.20","질문 제목2","질문내용2","#태그1","#태그2","#태그3"))
-//            add(Question("2024.01.01","질문 제목3","질문내용3","#태그1","#태그2","#태그3"))
-//            add(Question("2024.01.04","질문 제목4","질문내용4","#태그1","#태그2","#태그3"))
-//            add(Question("2024.01.07","질문 제목5","질문내용5","#태그1","#태그2",""))
-//        }
-
-//        // 임시 데이터 (삭제 요망)
-//        qDatas.apply {
-//            add(Question("2023.11.16","아르테미스 계획","현재 아르테미스 계획은 어떻게 되어 가고 있나요?"))
-//            add(Question("2023.12.20","퓨전 한복이란?","퓨전한복이랑 개량한복의 차이점이 뭔가요?"))
-//            add(Question("2024.12.26","콘크리트는 왜 분해되지 않나요?","콘크리트는 골재, 시멘트, 물 등을 가공해서 만든 것인데, 왜 다시 골재와 물로 분리할 수 없나요?"))
-//            add(Question("2024.01.04","가장 빠른 동물","가장 빠른 동물이 무엇인가요?"))
-//            add(Question("2024.01.07","필름카메라 필름 보관","필름카메라는 처음인데, 보관을 어떻게 해야 안전한가요?"))
-//        }
-
-//        val questionRVAdapter = QuestionRVAdapter(qDatas)
-//        binding.mainQuestionRv.adapter = questionRVAdapter
-//        binding.mainQuestionRv.layoutManager = GridLayoutManager(applicationContext, 2)
-//
-//        questionRVAdapter.setMyItemClickListner(object : QuestionRVAdapter.MyItemClickListner{
-//            override fun onItemClick(questionInfo: QuestionInfo) {
-//                val intent = Intent(this@MainActivity, DetailedActivity::class.java)
-//                val gson = Gson()
-//                val qJson = gson.toJson(question)
-//                intent.putExtra("question", qJson)
-//                intent.putExtra("qDatas", qDatas)
-//                startActivity(intent)
-//            }
-//        })
 
         binding.mainSearchBt.setOnClickListener {
             val intent = Intent(this@MainActivity, SearchActivity::class.java)

--- a/app/src/main/java/com/example/qp/QuestionRVAdapter.kt
+++ b/app/src/main/java/com/example/qp/QuestionRVAdapter.kt
@@ -37,7 +37,7 @@ class QuestionRVAdapter(private val qList: ArrayList<QuestionInfo>)
 
     inner class ViewHolder(val binding: ItemQuestionBinding) : RecyclerView.ViewHolder(binding.root){
         fun bind(questionInfo: QuestionInfo){
-            binding.itemTimeTv.text = questionInfo.createAt.toString()
+            binding.itemTimeTv.text = questionInfo.createdAt.toString()
             binding.itemQuestionTv.text = questionInfo.title
             if(questionInfo.hashtags?.isEmpty() == false){
                 /*for (tagInfo in questionInfo.hashtags!!) {

--- a/app/src/main/java/com/example/qp/QuestionResponse.kt
+++ b/app/src/main/java/com/example/qp/QuestionResponse.kt
@@ -29,8 +29,8 @@ data class QuestionInfo(
     @SerializedName(value="hit")val hit: Int?=0,
     @SerializedName(value="answerCount")val answerCount: Int?=0,
     @SerializedName(value="expertCount")val expertCount: Int?=0,
-    @SerializedName(value="createAt")val createAt: String?="",
-    @SerializedName(value="updateAt")var updateAt: String?="",
+    @SerializedName(value="createdAt")val createdAt: String?="",
+    @SerializedName(value="updatedAt")var updatedAt: String?="",
     @SerializedName(value="hashtags")val hashtags: ArrayList<TagInfo>?=null,
 ):Serializable
 

--- a/app/src/main/java/com/example/qp/SearchActivity.kt
+++ b/app/src/main/java/com/example/qp/SearchActivity.kt
@@ -26,7 +26,6 @@ class SearchActivity : AppCompatActivity() {
 
         binding.searchBackIv.setOnClickListener{
             val intent = Intent(this@SearchActivity, MainActivity::class.java)
-            intent.putExtra("isLogin", 1)
             startActivity(intent)
         }
 
@@ -75,7 +74,7 @@ class SearchActivity : AppCompatActivity() {
                                 filtered.clear()
                                 filtered.addAll(questionResponse.result.questions)
                                 setQuestionRVAdapter(filtered)
-                                Log.d("getQsResp",filtered.toString())
+                                Log.d("getFdResp",filtered.toString())
                             }
                             else -> {
                                 Log.d("SUCCESS/DATA_FAILURE", "응답 코드 오류입니다")
@@ -126,7 +125,6 @@ class SearchActivity : AppCompatActivity() {
         binding.searchRegisterBt.setOnClickListener {
             val intent = Intent(this@SearchActivity, WriteQuestionActivity::class.java)
             startActivity(intent)
-
         }
     }
 

--- a/app/src/main/java/com/example/qp/SearchActivity.kt
+++ b/app/src/main/java/com/example/qp/SearchActivity.kt
@@ -10,11 +10,13 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.GridLayoutManager
 import com.example.qp.databinding.ActivitySearchBinding
 import com.google.gson.Gson
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 class SearchActivity : AppCompatActivity() {
 
     lateinit var binding: ActivitySearchBinding
-    private var original = ArrayList<QuestionInfo>()
     private var filtered = ArrayList<QuestionInfo>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -33,45 +35,11 @@ class SearchActivity : AppCompatActivity() {
     }
 
     private fun searchResult(){
-        if(intent.hasExtra("qDatas")){
-            original = intent.getSerializableExtra("qDatas") as ArrayList<QuestionInfo>
-        }
-        filtered.addAll(original)
-
-        val questionRVAdapter = QuestionRVAdapter(filtered)
-        binding.searchMatchQuestionRv.adapter = questionRVAdapter
-        binding.searchMatchQuestionRv.layoutManager = GridLayoutManager(applicationContext, 2)
-
         val textListner = object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {
-                Log.d("qDatas 개수", original.size.toString())
-                val selected = ArrayList<QuestionInfo>()
-                for(i in original){
-                    val temp = i.title
-                    if( temp?.contains(query.toString()) == true){
-                        selected.add(i)
-                    }
-                }
+                getfilteredQuestions(query)
                 binding.searchRecentWord.isVisible = false
-                if(selected.size == 0){
-                    //이전 결과
-                    binding.searchMatchQuestionRv.isVisible = false
-                    //검색 결과 X
-                    binding.searchRegisterInfo.isVisible = true
-                    binding.searhNoResultTv.isVisible = true
-                }
-                else{
-                    //이전 결과
-                    binding.searchRegisterInfo.isVisible = false
-                    binding.searhNoResultTv.isVisible = false
-                    //검색 결과 O
-                    filtered = selected
-                    questionRVAdapter.setData(filtered)
-                    questionRVAdapter.notifyDataSetChanged()
-                    binding.searchMatchQuestionRv.isVisible = true
-                }
-                // 키보드 숨기기
-                binding.searchInputSv.clearFocus();
+                binding.searchInputSv.clearFocus() // 키보드 숨기기
                 return true
             }
             override fun onQueryTextChange(newText: String?): Boolean {
@@ -85,15 +53,73 @@ class SearchActivity : AppCompatActivity() {
             textListner.onQueryTextSubmit(binding.searchInputSv.query.toString())
         }
 
-        questionRVAdapter.setMyItemClickListner(object : QuestionRVAdapter.MyItemClickListner{
-            override fun onItemClick(questionInfo: QuestionInfo) {
-                val intent = Intent(this@SearchActivity, DetailedActivity::class.java)
-                val gson = Gson()
-                val qJson = gson.toJson(questionInfo)
-                intent.putExtra("question", qJson)
-                startActivity(intent)
-            }
-        })
+    }
+
+    private fun getfilteredQuestions(query: String?){
+        val questionService = getRetrofit().create(QuestionInterface::class.java)
+
+        questionService.getQuestions(0, 10, query) //스크롤에 따라 추가 페이징 할 것!
+            .enqueue(object: Callback<QuestionResponse> {
+                override fun onResponse(
+                    call: Call<QuestionResponse>,
+                    response: Response<QuestionResponse>
+                ) {
+                    if(response.isSuccessful && response.code() == 200){
+                        val questionResponse: QuestionResponse = response.body()!!
+
+                        Log.d("Q-RESPONSE/SUCCESS", questionResponse.toString())
+
+                        when(questionResponse.code){
+                            "QUESTION_2000" -> {
+                                Log.d("SUCCESS/DATA_LOAD", "리사이클러뷰의 데이터로 구성됩니다")
+                                filtered.clear()
+                                filtered.addAll(questionResponse.result.questions)
+                                setQuestionRVAdapter(filtered)
+                                Log.d("getQsResp",filtered.toString())
+                            }
+                            else -> {
+                                Log.d("SUCCESS/DATA_FAILURE", "응답 코드 오류입니다")
+                            }
+                        }
+                    }
+                }
+
+                override fun onFailure(call: Call<QuestionResponse>, t: Throwable) {
+                    Log.d("Q-RESPONSE/FAILURE", t.message.toString())
+                }
+
+            })
+    }
+
+    private fun setQuestionRVAdapter(filtered: ArrayList<QuestionInfo>){
+        if(filtered.size == 0){
+            //이전 결과
+            binding.searchMatchQuestionRv.isVisible = false
+            //검색 결과 X
+            binding.searchRegisterInfo.isVisible = true
+            binding.searhNoResultTv.isVisible = true
+        }
+        else{
+            //이전 결과
+            binding.searchRegisterInfo.isVisible = false
+            binding.searhNoResultTv.isVisible = false
+            //검색 결과 O
+            binding.searchMatchQuestionRv.isVisible = true
+
+            val questionRVAdapter = QuestionRVAdapter(filtered)
+            binding.searchMatchQuestionRv.adapter = questionRVAdapter
+            binding.searchMatchQuestionRv.layoutManager = GridLayoutManager(applicationContext, 2)
+
+            questionRVAdapter.setMyItemClickListner(object : QuestionRVAdapter.MyItemClickListner{
+                override fun onItemClick(questionInfo: QuestionInfo) {
+                    val intent = Intent(this@SearchActivity, DetailedActivity::class.java)
+                    val gson = Gson()
+                    val qJson = gson.toJson(questionInfo)
+                    intent.putExtra("question", qJson)
+                    startActivity(intent)
+                }
+            })
+        }
     }
 
     private fun register(){

--- a/app/src/main/java/com/example/qp/WriteQuestionActivity.kt
+++ b/app/src/main/java/com/example/qp/WriteQuestionActivity.kt
@@ -46,9 +46,7 @@ class WriteQuestionActivity: AppCompatActivity(),WriteQView {
         registerQuestion()
 
         binding.writeSearchBt.setOnClickListener {
-            val qDatas=intent.getSerializableExtra("qDatas") as ArrayList<QuestionInfo>
             val intent=Intent(this@WriteQuestionActivity,SearchActivity::class.java)
-            intent.putExtra("qDatas",qDatas)
             startActivity(intent)
         }
 

--- a/app/src/main/res/layout/item_question.xml
+++ b/app/src/main/res/layout/item_question.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="180dp"
+    android:layout_width="match_parent"
+    android:minWidth="180dp"
     android:layout_height="230dp"
     android:layout_marginTop="5dp"
     android:layout_marginBottom="5dp"


### PR DESCRIPTION
[개발사항]
-MainActivity와 SearchActivity 임시 데이터 삭제 및 백엔드 연동 구현 완료
 (백엔드 통신으로 얻어지는 데이터로 리사이클러뷰 구성)

[추가사항]
-QuestionResponse 오타 수정
-리사이클러뷰를 구성하는 item_question 크기 조정