### PR TITLE
전문가 답변 블러처리 및 피드백 수정사항

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,7 +45,8 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.google.code.gson:gson:2.8.7") //GSON
+    implementation("com.google.code.gson:gson:2.8.7")
+    implementation("androidx.databinding:databinding-runtime:8.2.2") //GSON
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/example/qp/DetailedActivity.kt
+++ b/app/src/main/java/com/example/qp/DetailedActivity.kt
@@ -60,9 +60,9 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
         binding.detailedLogoIv.setOnClickListener {
             UserApiClient.instance.logout { error ->
                 if (error != null) {
-                    Toast.makeText(this, "로그아웃 실패 $error", Toast.LENGTH_SHORT).show()
+                    QpToast.createToast(applicationContext,"로그아웃 실패 $error")?.show()
                 }else {
-                    Toast.makeText(this, "로그아웃 성공", Toast.LENGTH_SHORT).show()
+                    QpToast.createToast(applicationContext,"로그아웃 성공")?.show()
                     isLogin=false
                     AppData.qpUserID = 0
                     AppData.qpAccessToken = ""
@@ -85,7 +85,6 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
 
             setInit()
 
-            setQuestionMorePopup()
 
             //프로필로 화면 전환
             binding.detailedLoginSuccessBt.setOnClickListener {
@@ -99,6 +98,8 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
         }
 
         Log.d("detailedQOncreate", questionInfo.toString())
+
+        Log.d("userInfo",AppData.qpUserID.toString()+AppData.qpNickname)
     }
 
 
@@ -177,21 +178,22 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
             }
 
             override fun showLoginMsg() {
-                val dialog=SimpleDialog()
-                dialog.show(supportFragmentManager,"dialog")
+                QpToast.createToast(applicationContext)?.show()
             }
         })
 
         //답변 공간 펼치기
         binding.answerBtn.setOnClickListener {
-            showWriteAnswerEdit(true)
+            if(isLogin)
+                showWriteAnswerEdit(true)
+            else
+                QpToast.createToast(applicationContext)?.show()
         }
         //질문 알림 설정
         binding.answerNoticeBtn.setOnClickListener {
             Log.d("isLogin",isLogin.toString())
             if(!isLogin){
-                val dialog=SimpleDialog()
-                dialog.show(supportFragmentManager,"dialog")
+                QpToast.createToast(applicationContext)?.show()
             }
             else{
                 if(!isNotified){
@@ -211,6 +213,9 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
         binding.detailedLoginSuccessBt.setOnClickListener {
             startActivity(Intent(this, ProfileActivity::class.java))
         }
+
+        setQuestionMorePopup()
+
         //updateNotifyView()
     }
 
@@ -283,12 +288,13 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
         if(toNotify){
             binding.answerNoticeBtn.setImageResource(R.drawable.notification_on)
             isNotified=true
-            Toast.makeText(applicationContext,"답변 알림 설정",Toast.LENGTH_SHORT).show()
+            QpToast.createToast(applicationContext,"답변 알림 설정")?.show()
         }
         else{
             binding.answerNoticeBtn.setImageResource(R.drawable.notification_off)
             isNotified=false
-            Toast.makeText(applicationContext,"답변 알림 해제",Toast.LENGTH_SHORT).show()
+            QpToast.createToast(applicationContext,"답변 알림 해제")?.show()
+
         }
     }
 
@@ -343,68 +349,58 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
         lateinit var popupWindow: SimplePopup
         var isMine=questionInfo.user?.userId==AppData.qpUserID  //본인이 작성한 질문인지 여부
 
-        if(answerAdapter.isItemListEmpty()&&isMine){            //답변이 한개라도 있으면 수정&삭제 불가
             binding.questionMoreBtn.setOnClickListener {
-                val list= mutableListOf<String>().apply {
-                    add("수정하기")
-                    add("삭제하기")
-                    add("신고하기")
-                }
-                popupWindow=SimplePopup(applicationContext,list){_,_,position->
-                    when(position){
-                        0-> {   //수정하기
-                            val intent=Intent(this@DetailedActivity,ModifyQuestionActivity::class.java)
-                            intent.putExtra("modifyQuestion",questionInfo)
-                            startActivity(intent)
-                            Log.d("modifyLog",questionInfo.toString())
-                            Toast.makeText(applicationContext, "수정하기", Toast.LENGTH_SHORT).show()
-                        }
-                        1-> {   //삭제하기
-                            val check = "질문 작성자 아이디: " + questionInfo.user?.userId.toString() +
-                                    "\n로그인 유저 아이디: " + AppData.qpUserID
-                            Toast.makeText(applicationContext, check,Toast.LENGTH_SHORT).show()
-                            if(questionInfo.user?.userId == AppData.qpUserID){
-                                Toast.makeText(applicationContext, "질문 삭제",Toast.LENGTH_SHORT).show()
-                                deleteQ(AppData.qpAccessToken, questionInfo.questionId, AppData.qpUserID)
-                            }
-                            else{
-                                Toast.makeText(applicationContext,"자신이 작성한 질문만 삭제가능",Toast.LENGTH_SHORT).show()
-                            }
-                        }
-                        2-> {   //신고하기
-                            Toast.makeText(applicationContext, "신고하기", Toast.LENGTH_SHORT).show()
-                            if(!isLogin){
-                                val dialog=SimpleDialog()
-                                dialog.show(supportFragmentManager,"dialog")
-                            }
-                        }
-                    }
-                }
-                popupWindow.isOutsideTouchable=true
-                popupWindow.showAsDropDown(it,40,10)
-            }
-            }
-        else{
-            binding.questionMoreBtn.setOnClickListener {
-                val list= mutableListOf<String>().apply {
+                if(answerAdapter.isItemListEmpty()&&isMine&&isLogin){
+                    val list= mutableListOf<String>().apply {
+                        add("수정하기")
+                        add("삭제하기")
                         add("신고하기")
-                }
-                popupWindow=SimplePopup(applicationContext,list){_,_,position->
-                    when(position){
-                        0-> {
-                            Toast.makeText(applicationContext, "신고하기", Toast.LENGTH_SHORT).show()
-                            if(!isLogin){
-                                val dialog=SimpleDialog()
-                                dialog.show(supportFragmentManager,"dialog")
+                    }
+                    popupWindow=SimplePopup(applicationContext,list){_,_,position->
+                        when(position){
+                            0-> {   //수정하기
+                                val intent=Intent(this@DetailedActivity,ModifyQuestionActivity::class.java)
+                                intent.putExtra("modifyQuestion",questionInfo)
+                                startActivity(intent)
+                                Log.d("modifyLog",questionInfo.toString())
+                                Toast.makeText(applicationContext, "수정하기", Toast.LENGTH_SHORT).show()
+                            }
+                            1-> {   //삭제하기
+                                    QpToast.createToast(applicationContext,"질문 삭제")?.show()
+                                    deleteQ(AppData.qpAccessToken, questionInfo.questionId, AppData.qpUserID)
+                            }
+                            2-> {   //신고하기
+                                Toast.makeText(applicationContext, "신고하기", Toast.LENGTH_SHORT).show()
+                                if(!isLogin){
+                                    QpToast.createToast(applicationContext)?.show()
+                                }
                             }
                         }
                     }
+                    popupWindow.isOutsideTouchable=true
+                    popupWindow.showAsDropDown(it,40,10)
                 }
-                popupWindow.isOutsideTouchable=true
-                popupWindow.showAsDropDown(it,40,10)
-            }
+                else{                   //답변이 한개라도 있으면 수정&삭제 불가
+                    binding.questionMoreBtn.setOnClickListener {
+                        val list= mutableListOf<String>().apply {
+                            add("신고하기")
+                        }
+                        popupWindow=SimplePopup(applicationContext,list){_,_,position->
+                            when(position){
+                                0-> {
+                                    Toast.makeText(applicationContext, "신고하기", Toast.LENGTH_SHORT).show()
+                                    if(!isLogin){
+                                        QpToast.createToast(applicationContext)?.show()
+                                    }
+                                }
+                            }
+                        }
+                        popupWindow.isOutsideTouchable=true
+                        popupWindow.showAsDropDown(it,40,10)
+                    }
 
-        }
+                }
+            }
 
     }
 
@@ -465,7 +461,7 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
                         showWriteAnswerEdit(false)  //답변 작성 공간 접기
                         //updateNotifyView()
                         updateExpertNum()   //전문가 수 갱신
-                        Toast.makeText(applicationContext,"답변이 등록되었습니다.",Toast.LENGTH_SHORT).show()
+                        QpToast.createToast(applicationContext,"답변이 등록되었습니다")?.show()
                     }
                     else->{
                         Log.d("writeAnswer/FAIL",response.errorBody()?.string().toString())
@@ -526,7 +522,7 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
                     }
                     else->{
                         Log.d("modifyAnswer/FAIL",response.errorBody()?.string().toString())
-                        Toast.makeText(applicationContext,"답변 수정 실패",Toast.LENGTH_SHORT).show()
+                        QpToast.createToast(applicationContext,"답변 수정 실패+${response.errorBody()?.string().toString()}")?.show()
                     }
                 }
 
@@ -558,7 +554,7 @@ class DetailedActivity : AppCompatActivity(),DetailedQView{
                         }
                     }
                     else->{
-                        Toast.makeText(applicationContext,"답변 삭제 실패",Toast.LENGTH_SHORT).show()
+                        QpToast.createToast(applicationContext,"답변 삭제 실패:${response.errorBody()?.string().toString()}")?.show()
                         Log.d("deleteAnswer/FAIL",response.errorBody()?.string().toString())
                     }
                 }

--- a/app/src/main/java/com/example/qp/DetailedAnswerCommentRVAdapter.kt
+++ b/app/src/main/java/com/example/qp/DetailedAnswerCommentRVAdapter.kt
@@ -1,6 +1,7 @@
 package com.example.qp
 
 import android.content.Context
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,10 +10,12 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.recyclerview.widget.RecyclerView
 import com.example.qp.databinding.ItemAnswerCommentBinding
+import com.kakao.sdk.user.UserApiClient
 
 class DetailedAnswerCommentRVAdapter(context: Context ):RecyclerView.Adapter<DetailedAnswerCommentRVAdapter.ViewHolder>() {
     private var appContext=context
     private val items=ArrayList<AnswerInfo>()
+    private var isLogin=false
 
     interface CommentClickListener{
         fun onItemRemove(position:Int,answerId:Long)
@@ -28,11 +31,23 @@ class DetailedAnswerCommentRVAdapter(context: Context ):RecyclerView.Adapter<Det
         return ViewHolder(binding)
     }
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        checkLogin()
         holder.bind(position)
     }
 
     override fun getItemCount(): Int =items.size
 
+
+    fun checkLogin(){
+        UserApiClient.instance.accessTokenInfo { token, error ->
+            if (error != null) {
+                Log.e("TAG", "로그인 실패", error)
+            } else if (token != null) {
+                isLogin=true
+                Log.i("TAG", "로그인 성공 $token")
+            }
+        }
+    }
 
     inner class ViewHolder(val binding:ItemAnswerCommentBinding) : RecyclerView.ViewHolder(binding.root) {
 
@@ -51,8 +66,9 @@ class DetailedAnswerCommentRVAdapter(context: Context ):RecyclerView.Adapter<Det
 
         private fun showCommentMorePopup(answer: AnswerInfo,position:Int){
             lateinit var popupWindow:SimplePopup
-            if(AppData.qpUserID==answer.userId.toInt()){
-                binding.commentMoreBtn.setOnClickListener {
+            binding.commentMoreBtn.setOnClickListener {
+                if(AppData.qpUserID==answer.userId.toInt()&&isLogin){
+
                     val list= mutableListOf<String>().apply {
                         add("수정하기")
                         add("삭제하기")
@@ -74,22 +90,22 @@ class DetailedAnswerCommentRVAdapter(context: Context ):RecyclerView.Adapter<Det
                     popupWindow.isOutsideTouchable=true
                     popupWindow.showAsDropDown(it,40,10)
                 }
-            }
-            else{
-                binding.commentMoreBtn.setOnClickListener {
-                    val list= mutableListOf<String>().apply {
-                        add("신고하기")
-                    }
-                    popupWindow=SimplePopup(appContext,list){_,_,menuPos->
-                        when(menuPos){
-                            0-> Toast.makeText(appContext,"신고하기", Toast.LENGTH_SHORT).show()
+                else{
+                    binding.commentMoreBtn.setOnClickListener {
+                        val list= mutableListOf<String>().apply {
+                            add("신고하기")
                         }
+                        popupWindow=SimplePopup(appContext,list){_,_,menuPos->
+                            when(menuPos){
+                                0-> Toast.makeText(appContext,"신고하기", Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                        popupWindow.isOutsideTouchable=true
+                        popupWindow.showAsDropDown(it,40,10)
                     }
-                    popupWindow.isOutsideTouchable=true
-                    popupWindow.showAsDropDown(it,40,10)
                 }
-            }
 
+            }
         }
 
 

--- a/app/src/main/java/com/example/qp/QpToast.kt
+++ b/app/src/main/java/com/example/qp/QpToast.kt
@@ -1,0 +1,26 @@
+package com.example.qp
+
+import android.content.Context
+import android.content.res.Resources
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.widget.Toast
+import androidx.databinding.DataBindingUtil
+import com.example.qp.databinding.ItemToastBinding
+
+object QpToast {
+    fun createToast(context:Context,message:String="로그인이 필요한 기능입니다"): Toast?{
+        val inflater=LayoutInflater.from(context)
+        val binding:ItemToastBinding=ItemToastBinding.inflate(LayoutInflater.from(context))
+
+        binding.toastTv.text=message
+
+        return Toast(context).apply {
+            setGravity(Gravity.BOTTOM or Gravity.CENTER,0,50.toPx())
+            duration=Toast.LENGTH_SHORT
+            view=binding.root
+        }
+    }
+    private fun Int.toPx(): Int = (this * Resources.getSystem().displayMetrics.density).toInt()
+
+}

--- a/app/src/main/java/com/example/qp/SearchActivity.kt
+++ b/app/src/main/java/com/example/qp/SearchActivity.kt
@@ -183,8 +183,7 @@ class SearchActivity : AppCompatActivity() {
                 startActivity(intent)
             }
             else{
-                val dialog = SimpleDialog()
-                dialog.show(supportFragmentManager,"dialog")
+                QpToast.createToast(applicationContext)?.show()
             }
         }
     }

--- a/app/src/main/java/com/example/qp/WriteQuestionActivity.kt
+++ b/app/src/main/java/com/example/qp/WriteQuestionActivity.kt
@@ -133,7 +133,7 @@ class WriteQuestionActivity: AppCompatActivity() {
                     if(s.isNotEmpty())
                         if((s[s.length-1].code ==32 || s[s.length-1] =='\n') && s.isNotBlank()) {
                             if(!adapter.dupCheck(s.toString().trim())){
-                                Toast.makeText(applicationContext,"이미 추가함",Toast.LENGTH_SHORT).show()
+                                QpToast.createToast(applicationContext,"이미 추가된 태그입니다")?.show()
                                 return
                             }
                             adapter.addItem(s.toString().trim())
@@ -154,7 +154,7 @@ class WriteQuestionActivity: AppCompatActivity() {
 
         edittext.setOnClickListener {
             if(adapter.itemCount>=3){
-                Toast.makeText(applicationContext,"다시 입력하려면 기존 텍스트를 지워주세요",Toast.LENGTH_SHORT).show()
+                QpToast.createToast(applicationContext,"다시 입력하려면 기존 텍스트를 지워주세요")?.show()
             }
             else{
                 edittext.isFocusable=true
@@ -223,11 +223,12 @@ class WriteQuestionActivity: AppCompatActivity() {
 
 
                 }
-                else Toast.makeText(applicationContext,"동의가 체크되지 않음",Toast.LENGTH_SHORT).show()
+                else QpToast.createToast(applicationContext,"동의가 체크되지 않았습니다")?.show()
+
 
             }
             else{
-                Toast.makeText(applicationContext,"제목 또는 본문 형식이 유효하지 않습니다.",Toast.LENGTH_SHORT).show()
+                QpToast.createToast(applicationContext, "제목 또는 본문 형식이 유효하지 않습니다.")?.show()
             }
         }
     }
@@ -276,7 +277,7 @@ class WriteQuestionActivity: AppCompatActivity() {
                             }
 
                         val question = QuestionInfo(
-                            user=UserInfo(AppData.qpUserID,AppData.qpProfileImage,"User"),
+                            user=UserInfo(AppData.qpUserID,AppData.qpProfileImage,AppData.qpRole),
                             questionId = resp.result.questionId,
                             title = questionInfo.title,
                             content = questionInfo.content,
@@ -293,7 +294,7 @@ class WriteQuestionActivity: AppCompatActivity() {
                         intent.putExtra("question", qJson)
                         startActivity(intent)
                         finish()
-                        Toast.makeText(applicationContext, "등록 완료", Toast.LENGTH_SHORT).show()
+                        QpToast.createToast(applicationContext,"등록 완료")?.show()
                     }
                     else-> {
                         /*val question = QuestionInfo(
@@ -311,7 +312,7 @@ class WriteQuestionActivity: AppCompatActivity() {
                         finish()
                         Toast.makeText(applicationContext, "등록 완료", Toast.LENGTH_SHORT).show()*/
                         Log.d("writeQ/FAIL",response.errorBody()?.string().toString())
-                        Toast.makeText(applicationContext,"등록 실패",Toast.LENGTH_SHORT).show()
+                        QpToast.createToast(applicationContext,"등록 실패")?.show()
                     }
                 }
               }

--- a/app/src/main/res/layout/item_answer.xml
+++ b/app/src/main/res/layout/item_answer.xml
@@ -81,13 +81,12 @@
             android:background="@color/white"/>
 
         <LinearLayout
-            android:id="@+id/answer_comment_btn_layout"
+            android:id="@+id/answer_comment_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            app:layout_constraintEnd_toStartOf="@id/answer_comment_like_layout"
-            app:layout_constraintTop_toTopOf="@id/answer_comment_like_layout"
-            app:layout_constraintBottom_toBottomOf="@id/answer_comment_like_layout"
+            app:layout_constraintEnd_toStartOf="@id/answer_like_btn"
+            app:layout_constraintTop_toBottomOf="@id/answer_content_tv"
             android:layout_marginVertical="10dp"
             android:layout_marginHorizontal="7dp">
             <ImageView
@@ -109,25 +108,24 @@
         </LinearLayout>
 
         <LinearLayout
-            android:id="@+id/answer_comment_like_layout"
+            android:id="@+id/answer_like_btn"
             android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:maxHeight="0dp"
+            android:layout_height="wrap_content"
             android:orientation="horizontal"
             app:layout_constraintStart_toStartOf="@id/answer_more_btn"
             app:layout_constraintEnd_toEndOf="@id/answer_more_btn"
             app:layout_constraintTop_toBottomOf="@id/answer_content_tv"
             android:layout_marginHorizontal="5dp"
+            android:layout_marginVertical="10dp"
+
             android:gravity="center"
-            android:padding="0dp"
             >
-            <ImageButton
-                android:id="@+id/answer_like_btn"
+            <ImageView
+                android:id="@+id/answer_like_iv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="10dp"
                 android:layout_marginRight="3dp"
-                android:layout_marginBottom="2dp"
+                android:layout_gravity="center_vertical"
                 android:src="@drawable/like_off"
                 android:background="@color/white"/>
             <TextView
@@ -147,7 +145,7 @@
             android:id="@+id/comment_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/answer_comment_like_layout"
+            app:layout_constraintTop_toBottomOf="@id/answer_like_btn"
             android:layout_marginTop="0dp"
             android:layout_marginHorizontal="10dp"
             android:visibility="gone">

--- a/app/src/main/res/layout/item_toast.xml
+++ b/app/src/main/res/layout/item_toast.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<TextView
+    android:id="@+id/toast_tv"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="로그인이 필요한 기능입니다"
+    android:textColor="@color/white"
+    android:background="@drawable/box_orange"
+    android:paddingVertical="10dp"
+    android:paddingHorizontal="25dp"/>
+
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">QP</string>
     <string name="write_question_note">작성자님께서 궁금해하고 등록한 질문은 다른 사람들도 궁금해할 만한 질문들입니다.
-        \n\n질문에 대한 갑변을 구매하는 형식이기에 한 사람이라도 답변을 구매한다면 질문을 수정하거나 삭제할 수 없습니다.
+        \n\n질문에 대한 답변을 구매하는 형식이기에 한 사람이라도 답변을 구매한다면 질문을 수정하거나 삭제할 수 없습니다.
         \n\n이와 같은 이유로 작성하실 때 신중히 작성해주세요.</string>
     <string name="kakao_native_key">f376568845887c2131226627efc28926</string>
     <string name="kakao_key">kakaof376568845887c2131226627efc28926</string>


### PR DESCRIPTION
-전문가 답변 블러 처리, 댓글 펼치기&좋아요 버튼 막아놓음
-토스트 메시지 커스텀 : 제가 기존 토스트는 거의 새 토스트로 바꿔어 놓긴 했는데 사용하실 때                         QpToast.createToast(applicationContext,"보여질 메시지")?.show() 이렇게 사용하지면 됩니다
-비로그인 시 답변하기 버튼 막아놓기
-좋아요 버튼 영역 수정(확대)
-좋아요 누를 때 아이콘 색 안변하게 수정 (자신이 좋아요한 질문 조회 불가하므로..)
-질문 등록 유의사항 오타 수정

그외 질문 상세 화면에 "~명의 전문가가 답변했습니다" 텍스트는 정상적으로 보여지는 것 같습니다.
댓글 등록도 전문가 계정으로 작성했을 때 정상적으로 작성되고, 전문가 계정으로 했을 때 질문등록도 정상적으로 돼서 이 부분은 좀 더 살펴보겠습니다.. 이부분들은 혹시 테스트하시다가 오류 나시면 바로 말씀해주세
